### PR TITLE
Add ESLint File

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,35 @@
+{
+  "env": {
+    "es6": true
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "rules": {
+    "no-mixed-spaces-and-tabs": 2,
+    "indent": [2, 2],
+    "camelcase": 2,
+    "curly": 2,
+    "eqeqeq": [2, "smart"],
+    "func-style": [2, "expression"],
+    "semi": 2,
+    "no-extra-semi": 2,
+    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "semi-spacing": 1,
+    "key-spacing": 1,
+    "block-spacing": 1,
+    "comma-spacing": 1,
+    "no-multi-spaces": 1,
+    "space-before-blocks": 1,
+    "keyword-spacing": [1, { "before": true, "after": true }],
+    "space-infix-ops": 1,
+    "one-var": [1, { "uninitialized": "never", "initialized": "never" }],
+    "no-use-before-define": 2,
+    "comma-style": [2, "last"],
+    "quotes": [1, "single"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "rules": {
     "no-mixed-spaces-and-tabs": 2,
     "indent": [2, 2],
+    "max-len": ["warn", { "code": 80 }],
     "camelcase": 2,
     "curly": 2,
     "eqeqeq": [2, "smart"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,19 @@ git commit -s
 
 ## JavaScript Style
 
-This project follows the
-[Hack Reactor Style Guide](https://github.com/hackreactor-labs/eslint-config-hackreactor).
-It is recommended that any contributors set up ESLint with their text editor
-to automatically check style as they work.
+This project follows the basic
+[Hack Reactor Style Guide](https://github.com/hackreactor-labs/eslint-config-hackreactor),
+with the addition that lines should be limited to 80 characters in length. An
+`.eslintrc.json` file with these rules is included in the root project
+directory. Any contributor writing JavaScript code should
+[install ESLint](https://eslint.org/docs/user-guide/getting-started)
+and run it on their code before submitting a PR. The easiest way to do this is
+simply to run:
+
+```bash
+npm install -g eslint
+```
+
+```bash
+eslint ./
+```


### PR DESCRIPTION
To simplify ESLint usage, adds a JSON formatted copy of Hack Reactor's Style Guide ESLint to the root project directory.

Also adds a rule for an 80-character limit, and tweaks the Readme.