### PR TITLE
Add Moji Creation to CREATE_COLLECTION action

### DIFF
--- a/code/part-two/processor/actions/create_collection.js
+++ b/code/part-two/processor/actions/create_collection.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { NAMESPACE } = require('../utils/constants');
+const getAddress = require('../utils/addressing');
 const { hash, encode, reject } = require('../utils/helpers');
 
 
 const createCollection = (context, publicKey) => {
-  const address = NAMESPACE + '01' + hash(publicKey, 62);
+  const address = getAddress.collection(publicKey);
 
   return context.getState([ address ])
     .then(state => {

--- a/code/part-two/processor/actions/create_collection.js
+++ b/code/part-two/processor/actions/create_collection.js
@@ -1,11 +1,32 @@
 'use strict';
 
 const getAddress = require('../utils/addressing');
-const { hash, encode, reject } = require('../utils/helpers');
+const { NEW_MOJI_COUNT, DNA_LENGTH, GENE_SIZE } = require('../utils/constants');
+const { hash, encode, reject, getPrng } = require('../utils/helpers');
 
+const emptyArray = size => Array.apply(null, Array(size));
 
-const createCollection = (context, publicKey) => {
+const makeDna = prng => {
+  return emptyArray(DNA_LENGTH).map(() => {
+    const randomHex = prng(GENE_SIZE).toString(16);
+    return ('0000' + randomHex).slice(-4);
+  }).join('');
+};
+
+const makeMoji = (publicKey, prng) => {
+  return emptyArray(NEW_MOJI_COUNT).map(() => ({
+    dna: makeDna(prng),
+    collection: publicKey,
+    sire: null,
+    breeder: null,
+    sired: [],
+    bred: []
+  }));
+};
+
+const createCollection = (context, publicKey, signature) => {
   const address = getAddress.collection(publicKey);
+  const prng = getPrng(signature);
 
   return context.getState([ address ])
     .then(state => {
@@ -13,13 +34,23 @@ const createCollection = (context, publicKey) => {
         return reject('Collection already exists with key: ' + publicKey);
       }
 
-      const update = {};
-      update[address] = encode({
-        key: publicKey,
-        moji: []
+      const updates = {};
+      const mojiAddresses = [];
+      const moji = makeMoji(publicKey, prng);
+      const getMojiAddress = getAddress.moji(publicKey);
+
+      moji.forEach(moji => {
+        const address = getMojiAddress(moji.dna);
+        updates[address] = encode(moji);
+        mojiAddresses.push(address);
       });
 
-      return context.setState(update);
+      updates[address] = encode({
+        key: publicKey,
+        moji: mojiAddresses
+      });
+
+      return context.setState(updates);
     });
 };
 

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -23,8 +23,10 @@ class MojiHandler extends TransactionHandler {
     }
 
     const action = payload.action;
+    const publicKey = txn.header.signerPublicKey;
+
     if (action === 'CREATE_COLLECTION') {
-      return createCollection(context, txn.header.signerPublicKey);
+      return createCollection(context, publicKey, txn.signature);
     } else {
       return reject('Unknown action: ' + action);
     }

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -16,6 +16,9 @@ const getCollectionAddress = publicKey => {
 describe('Create Collection', function() {
   let handler = null;
   let context = null;
+  let txn = null;
+  let publicKey = null;
+  let address = null;
 
   before(function() {
     handler = new MojiHandler();
@@ -23,13 +26,12 @@ describe('Create Collection', function() {
 
   beforeEach(function() {
     context = new Context();
+    txn = new Txn({ action: 'CREATE_COLLECTION' });
+    publicKey = txn.header.signerPublicKey;
+    address = getCollectionAddress(publicKey);
   });
 
   it('should create a Collection at the correct address', function() {
-    const txn = new Txn({ action: 'CREATE_COLLECTION' });
-    const publicKey = txn.header.signerPublicKey;
-    const address = getCollectionAddress(publicKey);
-
     return handler.apply(txn, context)
       .then(() => {
         expect(context.state[address], 'Collection should exist').to.exist;
@@ -43,8 +45,6 @@ describe('Create Collection', function() {
   });
 
   it('should reject a public key that has already been used', function() {
-    const txn = new Txn({ action: 'CREATE_COLLECTION' });
-
     return handler.apply(txn, context)
       .then(() => handler.apply(txn, context))
       .catch(err => {

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -36,7 +36,75 @@ describe('Create Collection', function() {
         expect(collection.key, 'Collection should have a public key')
           .to.equal(publicKey);
         expect(collection.moji, 'Collection should have a moji array')
-          .to.deep.equal([]);
+          .to.be.an('array');
+      });
+  });
+
+  it('should create three moji for each new collection', function() {
+    return handler.apply(txn, context)
+      .then(() => {
+        const collection = decode(context.state[address]);
+        const mojiAddress = collection.moji[0];
+
+        expect(collection.moji, 'Collection should have three moji addresses')
+          .to.have.lengthOf(3);
+        expect(mojiAddress, 'Moji address should be 70 hex characters')
+          .to.match(/^[0-9a-f]{70}$/);
+        expect(context.state[mojiAddress], 'Moji should exist').to.exist;
+        const moji = decode(context.state[mojiAddress]);
+
+        expect(moji.dna, 'Moji DNA should be 36 hex characters')
+          .to.match(/^[0-9a-f]{36}$/);
+        expect(mojiAddress, 'Moji address match address generated from DNA')
+          .to.equal(getAddress.moji(publicKey)(moji.dna));
+      });
+  });
+
+  it('should create moji deterministically', function() {
+    let oldMoji = null;
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const collection = decode(context.state[address]);
+        oldMoji = collection.moji;
+
+        // Delete the created collection and cryptomoji
+        oldMoji.concat(address).forEach(addr => delete context.state[addr] );
+
+        return handler.apply(txn, context);
+      })
+      .then(() => {
+        const collection = decode(context.state[address]);
+
+        expect(collection.moji, 'New moji should match old moji')
+          .to.deep.equal(oldMoji);
+      });
+  });
+
+  it('should create moji pseudorandomly', function() {
+    let oldMoji = null;
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const collection = decode(context.state[address]);
+        oldMoji = collection.moji;
+
+        // Delete the created collection and cryptomoji
+        oldMoji.concat(address).forEach(addr => delete context.state[addr] );
+
+        // Modify a character in the signature to change the prng seed
+        const firstSig = txn.signature[0] !== 'f'
+          ? (parseInt(txn.signature[0], 16) + 1).toString(16)
+          : '0';
+        txn.signature = firstSig + txn.signature.slice(1);
+
+        return handler.apply(txn, context);
+      })
+      .then(() => {
+        const collection = decode(context.state[address]);
+
+        expect(collection.moji, 'Moji should not match when signature changes')
+          .to.not.deep.equal(oldMoji);
       });
   });
 

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -4,14 +4,10 @@ const { expect } = require('chai');
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
 
 const MojiHandler = require('../handler');
-const { NAMESPACE } = require('../utils/constants');
+const getAddress = require('../utils/addressing');
 const { hash, decode } = require('../utils/helpers');
 const Txn = require('./mocks/txn');
 const Context = require('./mocks/context');
-
-const getCollectionAddress = publicKey => {
-  return NAMESPACE + '01' + hash(publicKey, 62);
-};
 
 describe('Create Collection', function() {
   let handler = null;
@@ -28,7 +24,7 @@ describe('Create Collection', function() {
     context = new Context();
     txn = new Txn({ action: 'CREATE_COLLECTION' });
     publicKey = txn.header.signerPublicKey;
-    address = getCollectionAddress(publicKey);
+    address = getAddress.collection(publicKey);
   });
 
   it('should create a Collection at the correct address', function() {

--- a/code/part-two/processor/utils/addressing.js
+++ b/code/part-two/processor/utils/addressing.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { hash } = require('./helpers');
+const { NAMESPACE, TYPE_PREFIXES } = require('./constants');
+
+
+const getAddress = {};
+
+// Returns the address of a collection by its public key
+getAddress.collection = publicKey => {
+  return NAMESPACE +
+    TYPE_PREFIXES.COLLECTION +
+    hash(publicKey, 62);
+};
+
+// A curried function, fetching a moji address from owner key and dna
+getAddress.moji = ownerKey => {
+  const ownerHash = hash(ownerKey, 8);
+
+  return mojiDna => {
+    return NAMESPACE +
+      TYPE_PREFIXES.MOJI +
+      ownerHash +
+      hash(mojiDna, 54);
+  };
+};
+
+// A curried function, fetching an offer address from owner key and
+// the addresses of cryptomoji being offered
+getAddress.offer = ownerKey => {
+  const ownerHash = hash(ownerKey, 8);
+
+  return offeredAddresses => {
+    if (!Array.isArray(offeredAddresses)) {
+      offeredAddresses = [offeredAddresses];
+    }
+    return NAMESPACE +
+      TYPE_PREFIXES.OFFER +
+      ownerHash +
+      hash(offeredAddresses.join(''), 54);
+  };
+};
+
+// Returns the address of a sire listing by owner key
+getAddress.sireListing = ownerKey => {
+  return NAMESPACE +
+    TYPE_PREFIXES.SIRE_LISTING +
+    hash(ownerKey, 62);
+};
+
+module.exports = getAddress;

--- a/code/part-two/processor/utils/constants.js
+++ b/code/part-two/processor/utils/constants.js
@@ -7,15 +7,16 @@ const FAMILY_NAME = 'cryptomoji';
 const FAMILY_VERSION = '1.0';
 const NAMESPACE = hash(FAMILY_NAME, 6);
 
-const BLOCK_INFO = '00bl0c';
-const BLOCK_CONFIG_ADDRESS = BLOCK_INFO_NAMESPACE +
-  Array.map.apply(null, Array(64)).map(() => '0').join('');
-const BLOCK_INFO_NAMESPACE = BLOCK_INFO + '01';
+const TYPE_PREFIXES = {
+  COLLECTION: '00',
+  MOJI: '01',
+  OFFER: '02',
+  SIRE_LISTING: '03'
+};
 
 module.exports = {
   FAMILY_NAME,
   FAMILY_VERSION,
   NAMESPACE,
-  BLOCK_CONFIG_ADDRESS,
-  BLOCK_INFO_NAMESPACE
+  TYPE_PREFIXES
 };

--- a/code/part-two/processor/utils/constants.js
+++ b/code/part-two/processor/utils/constants.js
@@ -14,9 +14,16 @@ const TYPE_PREFIXES = {
   SIRE_LISTING: '03'
 };
 
+const NEW_MOJI_COUNT = 3;
+const DNA_LENGTH = 9;
+const GENE_SIZE = 2 ** (8 * 2);
+
 module.exports = {
   FAMILY_NAME,
   FAMILY_VERSION,
   NAMESPACE,
-  TYPE_PREFIXES
+  TYPE_PREFIXES,
+  NEW_MOJI_COUNT,
+  DNA_LENGTH,
+  GENE_SIZE
 };

--- a/code/part-two/processor/utils/constants.js
+++ b/code/part-two/processor/utils/constants.js
@@ -5,9 +5,17 @@ const { hash } = require('./helpers');
 
 const FAMILY_NAME = 'cryptomoji';
 const FAMILY_VERSION = '1.0';
+const NAMESPACE = hash(FAMILY_NAME, 6);
+
+const BLOCK_INFO = '00bl0c';
+const BLOCK_CONFIG_ADDRESS = BLOCK_INFO_NAMESPACE +
+  Array.map.apply(null, Array(64)).map(() => '0').join('');
+const BLOCK_INFO_NAMESPACE = BLOCK_INFO + '01';
 
 module.exports = {
-  FAMILY_NAME: FAMILY_NAME,
-  FAMILY_VERSION: FAMILY_VERSION,
-  NAMESPACE: hash(FAMILY_NAME, 6)
+  FAMILY_NAME,
+  FAMILY_VERSION,
+  NAMESPACE,
+  BLOCK_CONFIG_ADDRESS,
+  BLOCK_INFO_NAMESPACE
 };

--- a/code/part-two/processor/utils/helpers.js
+++ b/code/part-two/processor/utils/helpers.js
@@ -26,9 +26,26 @@ const reject = message => {
   });
 };
 
+// Takes a hex string and returns a function to generate pseudorandom,
+// but deterministic, numbers. Based on this github gist by blixt:
+// gist.github.com/blixt/f17b47c62508be59987b
+const getPrng = hex => {
+  let seed = parseInt(hex, 16);
+  if (!seed) {
+    seed = 1111111111;
+  }
+
+  // Returns a pseudorandom integer from 0 to max
+  return max => {
+    seed = seed * 16807 % 2147483647;
+    return Math.floor(seed / 2147483646 * max);
+  };
+};
+
 module.exports = {
   hash,
   encode,
   decode,
-  reject
+  reject,
+  getPrng
 };


### PR DESCRIPTION
Unfortunately, neither the BlockInfo transaction family, nor the BatchInjector API is usable without hacks, making it inappropriate for a curriculum for novice engineers. This is disappointing, but an opportunity to remove some complexity from the app. 

This means that Cryptomoji will no longer be created by the block publisher and distributed by lottery. Instead, each collection will get three Cryptomoji at signup. Furthermore, there will be no limit to how often moji may be bred or sired.

This PR adds the Moji creation part of that functionality. It can be tested with `npm test`, or by using the same `submit.js` script detailed in PR #32.

Closes #11 
Closes #12  
