### PR TITLE
Implement SELECT_SIRE action

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,6 @@
     "one-var": [1, { "uninitialized": "never", "initialized": "never" }],
     "no-use-before-define": 2,
     "comma-style": [2, "last"],
-    "quotes": [1, "single"]
+    "quotes": [1, "single", { "avoidEscape": true }]
   }
 }

--- a/code/part-two/client/Dockerfile
+++ b/code/part-two/client/Dockerfile
@@ -7,6 +7,7 @@ RUN echo "\
 \n\
 ServerName cryptomoji\n\
 AddDefaultCharset utf-8\n\
+\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 ProxyPass /api http://rest-api:8008\n\
@@ -15,9 +16,9 @@ RequestHeader set X-Forwarded-Path \"/api\"\n\
 \n\
 LoadModule rewrite_module modules/mod_rewrite.so\n\
 RewriteEngine On\n\
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]\n\
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d\n\
-RewriteRule ^ - [L]\n\
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f [OR]\n\
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d\n\
+RewriteCond %{REQUEST_FILENAME} !^/api\n\
 RewriteRule ^ /index.html\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf

--- a/code/part-two/client/source/Moji.jsx
+++ b/code/part-two/client/source/Moji.jsx
@@ -21,8 +21,8 @@ export class Moji extends React.Component {
             <tr><td>address</td><td>{moji.address}</td></tr>
             <tr><td>dna</td><td>{moji.dna}</td></tr>
             <tr>
-              <td>collection</td>
-              <td><Link to={'/browse/' + moji.collection}>{moji.collection}</Link></td>
+              <td>owner</td>
+              <td><Link to={'/browse/' + moji.owner}>{moji.owner}</Link></td>
             </tr>
             <tr>
               <td>sire</td>

--- a/code/part-two/client/source/utils/fakeApi.js
+++ b/code/part-two/client/source/utils/fakeApi.js
@@ -27,7 +27,7 @@ const GET_CRYPTOMOJI = (address = '', detailed) => {
   if (address.split('_')[0] === 'moji') {
     moji = utils.copy(blockchain[address]);
     if (moji && detailed) {
-      moji.collection = GET_COLLECTION(moji.collection, true);
+      moji.owner = GET_COLLECTION(moji.owner, true);
     }
   }
   return utils.delay(moji, 1000, 'Failed GET_CRYPTOMOJI!');

--- a/code/part-two/processor/actions/create_collection.js
+++ b/code/part-two/processor/actions/create_collection.js
@@ -16,7 +16,7 @@ const makeDna = prng => {
 const makeMoji = (publicKey, prng) => {
   return emptyArray(NEW_MOJI_COUNT).map(() => ({
     dna: makeDna(prng),
-    collection: publicKey,
+    owner: publicKey,
     sire: null,
     breeder: null,
     sired: [],

--- a/code/part-two/processor/actions/create_collection.js
+++ b/code/part-two/processor/actions/create_collection.js
@@ -31,7 +31,7 @@ const createCollection = (context, publicKey, signature) => {
   return context.getState([ address ])
     .then(state => {
       if (state[address].length > 0) {
-        return reject('Collection already exists with key: ' + publicKey);
+        return reject('Collection already exists with key:', publicKey);
       }
 
       const updates = {};

--- a/code/part-two/processor/actions/select_sire.js
+++ b/code/part-two/processor/actions/select_sire.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const getAddress = require('../utils/addressing');
+const { decode, encode, reject } = require('../utils/helpers');
+
+const selectSire = (context, publicKey, { sire }) => {
+  if (!sire) {
+    return reject('No sire specified');
+  }
+
+  const owner = getAddress.collection(publicKey);
+  return context.getState([ owner, sire ])
+    .then(state => {
+      if (state[owner].length === 0) {
+        return reject('Signer must have a collection:', publicKey);
+      }
+
+      if (state[sire].length === 0) {
+        return reject('Selected sire does not exist:', sire);
+      }
+
+      if (decode(state[sire]).owner !== publicKey) {
+        return reject('Selected sire is not owned by signer:', publicKey);
+      }
+
+      const update = {};
+      update[getAddress.sireListing(publicKey)] = encode({
+        sire,
+        owner: publicKey
+      });
+
+      return context.setState(update);
+    });
+};
+
+module.exports = selectSire;

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -19,7 +19,7 @@ class MojiHandler extends TransactionHandler {
     try {
       payload = decode(txn.payload);
     } catch (err) {
-      return reject('Failed to decode payload: ' + err);
+      return reject('Failed to decode payload:', err);
     }
 
     const action = payload.action;
@@ -28,7 +28,7 @@ class MojiHandler extends TransactionHandler {
     if (action === 'CREATE_COLLECTION') {
       return createCollection(context, publicKey, txn.signature);
     } else {
-      return reject('Unknown action: ' + action);
+      return reject('Unknown action:', action);
     }
   }
 }

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -6,6 +6,7 @@ const { FAMILY_NAME, FAMILY_VERSION, NAMESPACE } = require('./utils/constants');
 const { decode, reject } = require('./utils/helpers');
 
 const createCollection = require('./actions/create_collection');
+const selectSire = require('./actions/select_sire');
 
 
 class MojiHandler extends TransactionHandler {
@@ -27,6 +28,8 @@ class MojiHandler extends TransactionHandler {
 
     if (action === 'CREATE_COLLECTION') {
       return createCollection(context, publicKey, txn.signature);
+    } else if (action === 'SELECT_SIRE') {
+      return selectSire(context, publicKey, payload);
     } else {
       return reject('Unknown action:', action);
     }

--- a/code/part-two/processor/test/00-MojiHandler.js
+++ b/code/part-two/processor/test/00-MojiHandler.js
@@ -49,8 +49,6 @@ describe('Core MojiHandler Behavior', function() {
       .catch(err => {
         expect(err, 'Error should be an InvalidTransaction')
           .to.be.instanceOf(InvalidTransaction);
-        expect(err.message, 'Error message should include unknown action')
-          .to.include('BAD');
         return true;
       })
       .then(wasRejected => {

--- a/code/part-two/processor/test/00-MojiHandler.js
+++ b/code/part-two/processor/test/00-MojiHandler.js
@@ -22,8 +22,12 @@ describe('Core MojiHandler Behavior', function() {
 
   it('should return a Promise', function() {
     const txn = new Txn({ hello: 'world' });
-    expect(handler.apply(txn, context), 'Apply should return a promise')
+    const applyResult = handler.apply(txn, context);
+
+    expect(applyResult, 'Apply should return a promise')
       .to.be.an.instanceOf(Promise);
+
+    applyResult.catch(() => {});
   });
 
   it('should reject a poorly encoded payload', function() {

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -30,8 +30,8 @@ describe('Create Collection', function() {
   it('should create a Collection at the correct address', function() {
     return handler.apply(txn, context)
       .then(() => {
-        expect(context.state[address], 'Collection should exist').to.exist;
-        const collection = decode(context.state[address]);
+        expect(context._state[address], 'Collection should exist').to.exist;
+        const collection = decode(context._state[address]);
 
         expect(collection.key, 'Collection should have a public key')
           .to.equal(publicKey);
@@ -43,15 +43,15 @@ describe('Create Collection', function() {
   it('should create three moji for each new collection', function() {
     return handler.apply(txn, context)
       .then(() => {
-        const collection = decode(context.state[address]);
+        const collection = decode(context._state[address]);
         const mojiAddress = collection.moji[0];
 
         expect(collection.moji, 'Collection should have three moji addresses')
           .to.have.lengthOf(3);
         expect(mojiAddress, 'Moji address should be 70 hex characters')
           .to.match(/^[0-9a-f]{70}$/);
-        expect(context.state[mojiAddress], 'Moji should exist').to.exist;
-        const moji = decode(context.state[mojiAddress]);
+        expect(context._state[mojiAddress], 'Moji should exist').to.exist;
+        const moji = decode(context._state[mojiAddress]);
 
         expect(moji.dna, 'Moji DNA should be 36 hex characters')
           .to.match(/^[0-9a-f]{36}$/);
@@ -65,16 +65,16 @@ describe('Create Collection', function() {
 
     return handler.apply(txn, context)
       .then(() => {
-        const collection = decode(context.state[address]);
+        const collection = decode(context._state[address]);
         oldMoji = collection.moji;
 
         // Delete the created collection and cryptomoji
-        oldMoji.concat(address).forEach(addr => delete context.state[addr] );
+        oldMoji.concat(address).forEach(addr => delete context._state[addr] );
 
         return handler.apply(txn, context);
       })
       .then(() => {
-        const collection = decode(context.state[address]);
+        const collection = decode(context._state[address]);
 
         expect(collection.moji, 'New moji should match old moji')
           .to.deep.equal(oldMoji);
@@ -86,11 +86,11 @@ describe('Create Collection', function() {
 
     return handler.apply(txn, context)
       .then(() => {
-        const collection = decode(context.state[address]);
+        const collection = decode(context._state[address]);
         oldMoji = collection.moji;
 
         // Delete the created collection and cryptomoji
-        oldMoji.concat(address).forEach(addr => delete context.state[addr] );
+        oldMoji.concat(address).forEach(addr => delete context._state[addr] );
 
         // Modify a character in the signature to change the prng seed
         const firstSig = txn.signature[0] !== 'f'
@@ -101,7 +101,7 @@ describe('Create Collection', function() {
         return handler.apply(txn, context);
       })
       .then(() => {
-        const collection = decode(context.state[address]);
+        const collection = decode(context._state[address]);
 
         expect(collection.moji, 'Moji should not match when signature changes')
           .to.not.deep.equal(oldMoji);

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -114,8 +114,6 @@ describe('Create Collection', function() {
       .catch(err => {
         expect(err, 'Error should be an InvalidTransaction')
           .to.be.instanceOf(InvalidTransaction);
-        expect(err.message, 'Error message should include a public key')
-          .to.include(publicKey);
         return true;
       })
       .then(wasRejected => {

--- a/code/part-two/processor/test/01-CreateCollection.js
+++ b/code/part-two/processor/test/01-CreateCollection.js
@@ -23,7 +23,7 @@ describe('Create Collection', function() {
   beforeEach(function() {
     context = new Context();
     txn = new Txn({ action: 'CREATE_COLLECTION' });
-    publicKey = txn.header.signerPublicKey;
+    publicKey = txn._publicKey;
     address = getAddress.collection(publicKey);
   });
 
@@ -115,7 +115,7 @@ describe('Create Collection', function() {
         expect(err, 'Error should be an InvalidTransaction')
           .to.be.instanceOf(InvalidTransaction);
         expect(err.message, 'Error message should include a public key')
-          .to.include(txn.header.signerPublicKey);
+          .to.include(publicKey);
         return true;
       })
       .then(wasRejected => {

--- a/code/part-two/processor/test/02-SelectSire.js
+++ b/code/part-two/processor/test/02-SelectSire.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { expect } = require('chai');
+const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
+
+const MojiHandler = require('../handler');
+const getAddress = require('../utils/addressing');
+const { decode } = require('../utils/helpers');
+const Txn = require('./mocks/txn');
+const Context = require('./mocks/context');
+
+describe('Select Sire', function() {
+  let handler = null;
+  let context = null;
+  let privateKey = null;
+  let publicKey = null;
+  let address = null;
+  let sire = null;
+
+  before(function() {
+    handler = new MojiHandler();
+  });
+
+  beforeEach(function() {
+    const createTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    context = new Context();
+    privateKey = createTxn._privateKey;
+    publicKey = createTxn._publicKey;
+    address = getAddress.sireListing(publicKey);
+    return handler.apply(createTxn, context)
+      .then(() => {
+        const address = getAddress.collection(publicKey);
+        sire = decode(context._state[address]).moji[0];
+      });
+  });
+
+  it('should list a Sire at the correct address', function() {
+    const txn = new Txn({ action: 'SELECT_SIRE', sire }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        expect(context._state[address], 'Sire listing should exist').to.exist;
+        const listing = decode(context._state[address]);
+
+        expect(listing.owner, "Sire listing should include owner's public key")
+          .to.equal(publicKey);
+        expect(listing.sire, "Sire listing should include the sire's address")
+          .to.equal(sire);
+      });
+  });
+
+  it('should reject public keys with no Collection', function() {
+    delete context._state[getAddress.collection(publicKey)];
+    const txn = new Txn({ action: 'SELECT_SIRE', sire }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Sire listing should not exist')
+          .to.not.exist;
+      });
+  });
+
+  it('should reject listings with no sire', function() {
+    const txn = new Txn({ action: 'SELECT_SIRE' }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject sires that do not exist', function() {
+    delete context._state[sire];
+    const txn = new Txn({ action: 'SELECT_SIRE', sire }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Sire listing should not exist')
+          .to.not.exist;
+      });
+  });
+
+  it('should reject public keys that do not own the Sire', function() {
+    const createTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const address = getAddress.sireListing(createTxn._publicKey);
+    const txn = new Txn({ action: 'SELECT_SIRE', sire }, createTxn._privateKey);
+
+    return handler.apply(createTxn, context)
+      .then(() => handler.apply(txn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Sire listing should not exist')
+          .to.not.exist;
+      });
+  });
+});

--- a/code/part-two/processor/test/mocks/context.js
+++ b/code/part-two/processor/test/mocks/context.js
@@ -3,13 +3,13 @@
 // A mock state context object for testing
 class Context {
   constructor() {
-    this.state = {};
+    this._state = {};
   }
 
   getState(addresses) {
     return new Promise(resolve => {
       resolve(addresses.reduce((results, addr) => {
-        results[addr] = this.state[addr] || [];
+        results[addr] = this._state[addr] || [];
         return results;
       }, {}));
     });
@@ -18,7 +18,7 @@ class Context {
   setState (changes) {
     return new Promise(resolve => {
       const addresses = Object.keys(changes);
-      addresses.forEach(addr => { this.state[addr] = changes[addr]; });
+      addresses.forEach(addr => { this._state[addr] = changes[addr]; });
       resolve(addresses);
     });
   }

--- a/code/part-two/processor/utils/helpers.js
+++ b/code/part-two/processor/utils/helpers.js
@@ -20,9 +20,9 @@ const encode = obj => {
 const decode = encoded => JSON.parse(encoded.toString());
 
 // Returns a rejected promise with an InvalidTransaction
-const reject = message => {
+const reject = (...messages) => {
   return new Promise((_, reject) => {
-    reject(new InvalidTransaction(message));
+    reject(new InvalidTransaction(messages.join(' ')));
   });
 };
 


### PR DESCRIPTION
Includes some bug fixes, and an update to npm 5.8 as well. Adds new tests for the SELECT_SIRE action and implements it.

Closes #15 

### Run Tests
```bash
cd code/part-two/processor/
npm test
```

### Manually Test

Modify `code/part-two/client/source/services/transactions.js`:
- Replace `import` with `const`
- Replace `from 'XXXX';` with `= require('XXXX');`
- Remove `export`
- Add `module.exports = { createKeys, getSubmitter };`

Now from the terminal:
```bash
cd code/part-two/processor/
npm install
node
```

Now, from the node REPL:
```javascript
const { createKeys, getSubmitter } = require('./source/services/transactions')
const keys = createKeys()
const submit = getSubmitter(keys.privateKey)
submit({action: 'CREATE_COLLECTION'}).then(r => console.log(r)).catch(e => console.log(e))
```

Now, in a separate terminal run:
```bash
curl localhost:8000/api/state
```

Copy one of the moji addresses (they begin with `5f4d7601`), and paste it into this command back in the node REPL:
```javascript
submit({action: 'SELECT_SIRE', sire: '<pasteAddressHere>'}).then(r => console.log(r)).catch(e => console.log(e))
```

Go back to your other tab and curl state again:
```bash
curl localhost:8000/api/state
```

You should now see a sire listing with an address beginning with `5f4d7603`. You can decode the data by copying it into the Node REPL if you like:
```javascript
Buffer.from('<pasteDataStringHere>', 'base64').toString()
```

There should be an owner that matches your public key, and a sire that matches the cryptomoji address you copied in.