### PR TITLE
Implement BREED_MOJI action

### DIFF
--- a/code/part-two/client/source/services/parseDna.js
+++ b/code/part-two/client/source/services/parseDna.js
@@ -78,9 +78,8 @@ const hexToInts = hexString => {
 // Converts an integer into an array of booleans
 const intToSpacingGuide = (spacingInt) => {
   const bits = spacingInt.toString(2);
-  const padding = emptyArray(DNA_BITS).map(() => '0').join('');
 
-  return (padding + bits).slice(-DNA_BITS)
+  return ('0'.repeat(DNA_BITS) + bits).slice(-DNA_BITS)
     .split('')
     .map(bit => !Number(bit))
     .map((space, i, spaces) => {

--- a/code/part-two/processor/actions/breed_moji.js
+++ b/code/part-two/processor/actions/breed_moji.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const getAddress = require('../utils/addressing');
+const { DNA_BITS, AVERAGE_CHANCE, SIRE_CHANCE } = require('../utils/constants');
+const { encode, decode, reject, getPrng } = require('../utils/helpers');
+
+
+const HEX_SIZE = DNA_BITS / 4;
+
+const geneToInts = gene => {
+  return gene
+    .match(RegExp(`[0-9a-f]{${HEX_SIZE},${HEX_SIZE}}`, 'g'))
+    .map(hex => parseInt(hex, 16));
+};
+
+const combineDna = (sire, breeder, prng) => {
+  const sireGenes = geneToInts(sire);
+  const breederGenes = geneToInts(breeder);
+
+  return sireGenes
+    .map((sireGene, i) => [ sireGene, breederGenes[i] ])
+    .map(([ sireGene, breederGene ]) => {
+      if (prng(1000) < AVERAGE_CHANCE) {
+        return Math.floor((sireGene + breederGene) / 2);
+      }
+
+      if (prng(1000) < SIRE_CHANCE) {
+        return sireGene;
+      }
+
+      return breederGene;
+    })
+    .map(gene => ('0'.repeat(HEX_SIZE) + gene.toString(16)).slice(-HEX_SIZE))
+    .join('');
+};
+
+const breedMoji = (context, publicKey, { sire, breeder }, signature) => {
+  if (!sire) {
+    return reject('No sire specified');
+  }
+  if (!breeder) {
+    return reject('No breeder specified');
+  }
+
+  const owner = getAddress.collection(publicKey);
+  const prng = getPrng(signature);
+
+  return context.getState([ owner, sire, breeder ])
+    .then(state => {
+      if (state[owner].length === 0) {
+        return reject('Signer must have a collection:', publicKey);
+      }
+
+      if (state[sire].length === 0) {
+        return reject('Specified sire does not exist:', sire);
+      }
+
+      if (state[breeder].length === 0) {
+        return reject('Specified breeder does not exist:', breeder);
+      }
+
+      const ownerState = decode(state[owner]);
+      const sireState = decode(state[sire]);
+      const breederState = decode(state[breeder]);
+      const listing = getAddress.sireListing(sireState.owner);
+
+      if (breederState.owner !== publicKey) {
+        return reject('Breeder must be owned by signer:', breeder);
+      }
+
+      return context.getState([ listing ])
+        .then(state => {
+          const isNotListed = state[listing].length === 0
+            || decode(state[listing]).sire !== sire;
+
+          if (isNotListed) {
+            return reject('Specified sire is not listed:', sire);
+          }
+
+          const dna = combineDna(sireState.dna, breederState.dna, prng);
+          const address = getAddress.moji(publicKey)(dna);
+          const child = {
+            dna,
+            sire,
+            breeder,
+            owner: publicKey,
+            sired: [],
+            bred: []
+          };
+
+          sireState.sired.push(address);
+          breederState.bred.push(address);
+          ownerState.moji.push(address);
+
+          const updates = {};
+          updates[address] = encode(child);
+          updates[sire] = encode(sireState);
+          updates[breeder] = encode(breederState);
+          updates[owner] = encode(ownerState);
+
+          return context.setState(updates);
+        });
+    });
+};
+
+module.exports = breedMoji;

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -7,6 +7,7 @@ const { decode, reject } = require('./utils/helpers');
 
 const createCollection = require('./actions/create_collection');
 const selectSire = require('./actions/select_sire');
+const breedMoji = require('./actions/breed_moji');
 
 
 class MojiHandler extends TransactionHandler {
@@ -30,6 +31,8 @@ class MojiHandler extends TransactionHandler {
       return createCollection(context, publicKey, txn.signature);
     } else if (action === 'SELECT_SIRE') {
       return selectSire(context, publicKey, payload);
+    } else if (action === 'BREED_MOJI') {
+      return breedMoji(context, publicKey, payload, txn.signature);
     } else {
       return reject('Unknown action:', action);
     }

--- a/code/part-two/processor/test/03-BreedMoji.js
+++ b/code/part-two/processor/test/03-BreedMoji.js
@@ -1,0 +1,237 @@
+'use strict';
+
+const { expect } = require('chai');
+const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
+
+const MojiHandler = require('../handler');
+const getAddress = require('../utils/addressing');
+const { decode } = require('../utils/helpers');
+const Txn = require('./mocks/txn');
+const Context = require('./mocks/context');
+
+describe('Breed Moji', function() {
+  let handler = null;
+  let context = null;
+  let privateKey = null;
+  let publicKey = null;
+  let sireOwnerKey = null;
+  let sire = null;
+  let breeder = null;
+
+  before(function() {
+    handler = new MojiHandler();
+  });
+
+  beforeEach(function() {
+    const sireOwnerTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const breederOwnerTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    context = new Context();
+    privateKey = breederOwnerTxn._privateKey;
+    publicKey = breederOwnerTxn._publicKey;
+    sireOwnerKey = sireOwnerTxn._publicKey;
+
+    return Promise.all([
+      handler.apply(sireOwnerTxn, context),
+      handler.apply(breederOwnerTxn, context)
+    ])
+      .then(() => {
+        const sireOwnerAddress = getAddress.collection(sireOwnerKey);
+        const breederOwnerAddress = getAddress.collection(publicKey);
+
+        sire = decode(context._state[sireOwnerAddress]).moji[0];
+        breeder = decode(context._state[breederOwnerAddress]).moji[0];
+
+        const privateKey = sireOwnerTxn._privateKey;
+        const sireTxn = new Txn({ action: 'SELECT_SIRE', sire }, privateKey);
+        return handler.apply(sireTxn, context);
+      });
+  });
+
+  it("should create a new moji for the breeder's owner", function() {
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should have four cryptomoji')
+          .to.have.lengthOf(4);
+
+        const child = decode(context._state[owner.moji[3]]);
+
+        expect(child.owner, "Child moji should include the owner's public key")
+          .to.equal(publicKey);
+        expect(child.sire, "Child moji should include the sire's address")
+          .to.equal(sire);
+        expect(child.breeder, "Child moji should include the breeder's address")
+          .to.equal(breeder);
+      });
+  });
+
+  it('should add a new sired moji for the sire', function() {
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const sireMoji = decode(context._state[sire]);
+        expect(sireMoji.sired, 'Sire should have one sired moji')
+          .to.have.lengthOf(1);
+        expect(sireMoji.bred, 'Sire should still not have bred')
+          .to.be.empty;
+      });
+  });
+
+  it('should add a new bred moji for the breeder', function() {
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const breederMoji = decode(context._state[breeder]);
+        expect(breederMoji.bred, 'Breeder should have one bred moji')
+          .to.have.lengthOf(1);
+        expect(breederMoji.sired, 'Breeder should still not have sired')
+          .to.be.empty;
+      });
+  });
+
+  it('should reject public keys with no Collection', function() {
+    delete context._state[getAddress.collection(publicKey)];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject breedings with no sire', function() {
+    const txn = new Txn({ action: 'BREED_MOJI', breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject sires that do not exist', function() {
+    delete context._state[sire];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject breedings with no breeder', function() {
+    const txn = new Txn({ action: 'BREED_MOJI', sire }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject breeders that do not exist', function() {
+    delete context._state[breeder];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject sires when there is no listing', function() {
+    delete context._state[getAddress.sireListing(sireOwnerKey)];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject sires when another moji is listed', function() {
+    const ownerAddress = getAddress.collection(sireOwnerKey);
+    const sire = decode(context._state[ownerAddress]).moji[1];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject breeders not owned by the signer', function() {
+    const sireOwnerAddress = getAddress.collection(sireOwnerKey);
+    const sireOwner = decode(context._state[sireOwnerAddress]);
+    const breeder = sireOwner.moji[1];
+    const txn = new Txn({ action: 'BREED_MOJI', sire, breeder }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const owner = decode(context._state[getAddress.collection(publicKey)]);
+        expect(owner.moji, 'Owner should still have just three cryptomoji')
+          .to.have.lengthOf(3);
+      });
+  });
+});

--- a/code/part-two/processor/utils/constants.js
+++ b/code/part-two/processor/utils/constants.js
@@ -16,7 +16,10 @@ const TYPE_PREFIXES = {
 
 const NEW_MOJI_COUNT = 3;
 const DNA_LENGTH = 9;
-const GENE_SIZE = 2 ** (8 * 2);
+const DNA_BITS = 2 * 8;
+const GENE_SIZE = 2 ** DNA_BITS;
+const AVERAGE_CHANCE = 200;
+const SIRE_CHANCE = 600;
 
 module.exports = {
   FAMILY_NAME,
@@ -25,5 +28,8 @@ module.exports = {
   TYPE_PREFIXES,
   NEW_MOJI_COUNT,
   DNA_LENGTH,
-  GENE_SIZE
+  DNA_BITS,
+  GENE_SIZE,
+  AVERAGE_CHANCE,
+  SIRE_CHANCE
 };


### PR DESCRIPTION
~Based on PR #48, only the last two commits are actually a part of this PR.~

Allows you to breed two cryptomoji.

Closes #16 

### Run Tests
```bash
cd code/part-two/processor/
npm test
```

### Manually Test
Follow the steps in PR #48, then from your Node REPL:

```javascript
const keys2 = createKeys()
const submit2 = getSubmitter(keys2.privateKey)
submit2({action: 'CREATE_COLLECTION'}).then(r => console.log(r)).catch(e => console.log(e))
```

Then check state for the address of one of new collection's moji:
```bash
curl localhost:8000/api/state
```

Then, using that address, and the address of the moji you already selected as a sire:
```javascript
submit2({action: 'BREED_MOJI', sire: '<pasteAddressHere>', breeder: '<pasteBreederAddressHere>'}).then(r => console.log(r)).catch(e => console.log(e))
```

If you query state again, you should see that the new collection now has four moji. If you decode the state of that moji, you should see that it lists the address of its sire and breeder:
```javascript
Buffer.from('<pasteDataStringHere>', 'base64').toString()
```