### PR TITLE
Implement CREATE_OFFER action

### DIFF
--- a/code/part-two/processor/actions/create_offer.js
+++ b/code/part-two/processor/actions/create_offer.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const getAddress = require('../utils/addressing');
+const { decode, encode, reject } = require('../utils/helpers');
+
+
+const createOffer = (context, publicKey, { moji }) => {
+  if (!moji || moji.length === 0) {
+    return reject('No moji specified');
+  }
+
+  moji = moji.sort();
+  const owner = getAddress.collection(publicKey);
+  const offer = getAddress.offer(publicKey)(moji);
+  const listing = getAddress.sireListing(publicKey);
+
+  return context.getState(moji.concat(owner, offer, listing))
+    .then(state => {
+      if (state[offer].length !== 0) {
+        return reject('An offer for these moji already exists:', offer);
+      }
+
+      if (state[owner].length === 0) {
+        return reject('Signer must have a collection:', publicKey);
+      }
+
+      const sire = state[listing].length !== 0
+        ? decode(state[listing]).sire
+        : null;
+
+      for (let mojiAddress of moji) {
+        if (state[mojiAddress].length === 0) {
+          return reject('Specified moji does not exist:', mojiAddress);
+        }
+
+        if (decode(state[mojiAddress]).owner !== publicKey) {
+          return reject('Specified moji not owned by signer:', mojiAddress);
+        }
+
+        if (sire && mojiAddress === sire) {
+          return reject('Specified moji listed as a sire:', mojiAddress);
+        }
+      }
+
+      const update = {};
+      update[offer] = encode({
+        moji,
+        owner: publicKey,
+        responses: []
+      });
+
+      return context.setState(update);
+    });
+};
+
+module.exports = createOffer;

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -8,6 +8,7 @@ const { decode, reject } = require('./utils/helpers');
 const createCollection = require('./actions/create_collection');
 const selectSire = require('./actions/select_sire');
 const breedMoji = require('./actions/breed_moji');
+const createOffer = require('./actions/create_offer');
 
 
 class MojiHandler extends TransactionHandler {
@@ -33,6 +34,8 @@ class MojiHandler extends TransactionHandler {
       return selectSire(context, publicKey, payload);
     } else if (action === 'BREED_MOJI') {
       return breedMoji(context, publicKey, payload, txn.signature);
+    } else if (action === 'CREATE_OFFER') {
+      return createOffer(context, publicKey, payload);
     } else {
       return reject('Unknown action:', action);
     }

--- a/code/part-two/processor/test/04-CreateOffer.js
+++ b/code/part-two/processor/test/04-CreateOffer.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const { expect } = require('chai');
+const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
+
+const MojiHandler = require('../handler');
+const getAddress = require('../utils/addressing');
+const { decode } = require('../utils/helpers');
+const Txn = require('./mocks/txn');
+const Context = require('./mocks/context');
+
+describe('Create Offer', function() {
+  let handler = null;
+  let context = null;
+  let privateKey = null;
+  let publicKey = null;
+  let address = null;
+  let moji = null;
+
+  before(function() {
+    handler = new MojiHandler();
+  });
+
+  beforeEach(function() {
+    const createTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    context = new Context();
+    privateKey = createTxn._privateKey;
+    publicKey = createTxn._publicKey;
+    return handler.apply(createTxn, context)
+      .then(() => {
+        const ownerAddress = getAddress.collection(publicKey);
+        moji = decode(context._state[ownerAddress]).moji.sort();
+        address = getAddress.offer(publicKey)(moji);
+      });
+  });
+
+  it('should create an Offer for multiple moji', function() {
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        expect(context._state[address], 'Offer should exist').to.exist;
+        const offer = decode(context._state[address]);
+
+        expect(offer.owner, "Offer should include owner's public key")
+          .to.equal(publicKey);
+        expect(offer.moji, 'Offer should include the moji offered')
+          .to.deep.equal(moji);
+        expect(offer.responses, 'Offer should include an empty responses array')
+          .to.deep.equal([]);
+      });
+  });
+
+  it('should create an Offer for a single moji', function() {
+    moji = moji.slice(0, 1);
+    const address = getAddress.offer(publicKey)(moji);
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        expect(context._state[address], 'Offer should exist').to.exist;
+        const offer = decode(context._state[address]);
+
+        expect(offer.moji, 'Offer should include the moji offered')
+          .to.deep.equal(moji);
+      });
+  });
+
+  it('should sort the moji in the response', function() {
+    moji = moji.reverse();
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const offerMoji = decode(context._state[address]).moji;
+        expect(offerMoji, 'Response should sort the offered moji')
+          .to.have.ordered.members(moji.sort());
+      });
+  });
+
+  it('should reject public keys with no Collection', function() {
+    delete context._state[getAddress.collection(publicKey)];
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Offer should not exist').to.not.exist;
+      });
+  });
+
+  it('should reject an Offer without any moji', function() {
+    const address = getAddress.offer(publicKey)([]);
+    const txn = new Txn({ action: 'CREATE_OFFER', moji: [] }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Offer should not exist').to.not.exist;
+      });
+  });
+
+  it('should reject an Offer with a moji that does not exist', function() {
+    delete context._state[moji[1]];
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Offer should not exist').to.not.exist;
+      });
+  });
+
+  it('should reject an Offer that includes a Sire', function() {
+    const sire = moji[1];
+    const sireTxn = new Txn({ action: 'SELECT_SIRE', sire }, privateKey);
+    const offerTxn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(sireTxn, context)
+      .then(() => handler.apply(offerTxn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Offer should not exist').to.not.exist;
+      });
+  });
+
+  it('should reject an Offer for moji already in Offer', function() {
+    const firstTxn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+    moji = moji.reverse();
+    const secondTxn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(firstTxn, context)
+      .then(() => handler.apply(secondTxn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject public keys that do not own the moji', function() {
+    const createTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const privateKey = createTxn._privateKey;
+    const address = getAddress.offer(createTxn._publicKey)(moji);
+    const txn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+
+    return handler.apply(createTxn, context)
+      .then(() => handler.apply(txn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[address], 'Offer should not exist').to.not.exist;
+      });
+  });
+});

--- a/code/part-two/processor/utils/addressing.js
+++ b/code/part-two/processor/utils/addressing.js
@@ -37,7 +37,7 @@ getAddress.offer = ownerKey => {
     return NAMESPACE +
       TYPE_PREFIXES.OFFER +
       ownerHash +
-      hash(offeredAddresses.join(''), 54);
+      hash(offeredAddresses.sort().join(''), 54);
   };
 };
 


### PR DESCRIPTION
~Based off of PR #48 and PR #49, only the last two commits are a part of this PR for review purposes.~

Implements the CREATE_OFFER action, with tests. 

Closes #17 

### Run Tests
```bash
cd code/part-two/processor/
npm test
```

### Manually Test
Follow the steps in PR #48, as far as creating a collection. Then copy a moji address from state:
```bash
curl localhost:8000/api/state
```

And paste it into your Node REPL:

```javascript
submit({action: 'CREATE_OFFER', moji: ['<pasteMojiAddressHere>']}).then(r => console.log(r)).catch(e => console.log(e))
```

If you query state again, you should see that there is an offer in state with an address beginning with `5f4d7602`. If you decode the data, you should see that it lists the public key of its owner, and address of the moji being offered:
```javascript
Buffer.from('<pasteDataStringHere>', 'base64').toString()
```