### PR TITLE
Implement CANCEL_OFFER action

### DIFF
--- a/code/part-two/processor/actions/cancel_offer.js
+++ b/code/part-two/processor/actions/cancel_offer.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const getAddress = require('../utils/addressing');
+const { decode, encode, reject } = require('../utils/helpers');
+
+
+const cancelOffer = (context, publicKey, { offer }) => {
+  if (!offer) {
+    return reject('No offer specified');
+  }
+
+  const owner = getAddress.collection(publicKey);
+
+  return context.getState([ owner, offer ])
+    .then(state => {
+      if (state[owner].length === 0) {
+        return reject('Signer must have a collection:', publicKey);
+      }
+
+      if (state[offer].length === 0) {
+        return reject('Specified offer does not exist:', offer);
+      }
+
+      if (decode(state[offer]).owner !== publicKey) {
+        return reject('Specified offer not owned by signer:', offer);
+      }
+
+      return context.deleteState([offer]);
+    });
+};
+
+module.exports = cancelOffer;

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -9,6 +9,7 @@ const createCollection = require('./actions/create_collection');
 const selectSire = require('./actions/select_sire');
 const breedMoji = require('./actions/breed_moji');
 const createOffer = require('./actions/create_offer');
+const cancelOffer = require('./actions/cancel_offer');
 
 
 class MojiHandler extends TransactionHandler {
@@ -36,6 +37,8 @@ class MojiHandler extends TransactionHandler {
       return breedMoji(context, publicKey, payload, txn.signature);
     } else if (action === 'CREATE_OFFER') {
       return createOffer(context, publicKey, payload);
+    } else if (action === 'CANCEL_OFFER') {
+      return cancelOffer(context, publicKey, payload);
     } else {
       return reject('Unknown action:', action);
     }

--- a/code/part-two/processor/test/05-CancelOffer.js
+++ b/code/part-two/processor/test/05-CancelOffer.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { expect } = require('chai');
+const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
+
+const MojiHandler = require('../handler');
+const getAddress = require('../utils/addressing');
+const { decode } = require('../utils/helpers');
+const Txn = require('./mocks/txn');
+const Context = require('./mocks/context');
+
+describe('Cancel Offer', function() {
+  let handler = null;
+  let context = null;
+  let privateKey = null;
+  let publicKey = null;
+  let offer = null;
+
+  before(function() {
+    handler = new MojiHandler();
+  });
+
+  beforeEach(function() {
+    context = new Context();
+    const collecTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    privateKey = collecTxn._privateKey;
+    publicKey = collecTxn._publicKey;
+    return handler.apply(collecTxn, context)
+      .then(() => {
+        const address = getAddress.collection(publicKey);
+        const moji = decode(context._state[address]).moji;
+        offer = getAddress.offer(publicKey)(moji);
+        const offerTxn = new Txn({ action: 'CREATE_OFFER', moji }, privateKey);
+        return handler.apply(offerTxn, context);
+      });
+  });
+
+  it('should delete a canceled offer', function() {
+    const txn = new Txn({ action: 'CANCEL_OFFER', offer }, privateKey);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        expect(context._state[offer], 'Offer should not exist').to.not.exist;
+      });
+  });
+
+  it('should reject public keys with no Collection', function() {
+    delete context._state[getAddress.collection(publicKey)];
+    const txn = new Txn({ action: 'CANCEL_OFFER', offer }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[offer], 'Offer should still exist').to.exist;
+      });
+  });
+
+  it('should reject canceling an offer that is not set', function() {
+    const txn = new Txn({ action: 'CANCEL_OFFER' }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject canceling an offer that does not exist', function() {
+    delete context._state[offer];
+    const txn = new Txn({ action: 'CANCEL_OFFER', offer }, privateKey);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject public keys that do not own the offer', function() {
+    const collecTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const privateKey = collecTxn._privateKey;
+    const txn = new Txn({ action: 'CANCEL_OFFER', offer }, privateKey);
+
+    return handler.apply(collecTxn, context)
+      .then(() => handler.apply(txn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        expect(context._state[offer], 'Offer should still exist').to.exist;
+      });
+  });
+});

--- a/code/part-two/processor/test/mocks/context.js
+++ b/code/part-two/processor/test/mocks/context.js
@@ -15,10 +15,17 @@ class Context {
     });
   }
 
-  setState (changes) {
+  setState(changes) {
     return new Promise(resolve => {
       const addresses = Object.keys(changes);
       addresses.forEach(addr => { this._state[addr] = changes[addr]; });
+      resolve(addresses);
+    });
+  }
+
+  deleteState(addresses) {
+    return new Promise(resolve => {
+      addresses.forEach(address => { delete this._state[address]; });
       resolve(addresses);
     });
   }


### PR DESCRIPTION
Based off of PR #49 and PR #50, only the last three commits are a part of this PR for review purposes.

Implements the CANCEL_OFFER action, with tests. 

Closes #18 

### Run Tests
```bash
cd code/part-two/processor/
npm test
```

### Manually Test
Follow the steps in PR #50, as far as creating a collection. Then copy the offer address from state:
```bash
curl localhost:8000/api/state
```

And paste it into your Node REPL:

```javascript
submit({action: 'CANCEL_OFFER', moji: ['<pasteOfferAddressHere>']}).then(r => console.log(r)).catch(e => console.log(e))
```

If you query state again, you should see that there is no longer an offer in state.