### PR TITLE
Implement ADD_RESPONSE action

### DIFF
--- a/code/part-two/processor/actions/add_response.js
+++ b/code/part-two/processor/actions/add_response.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const getAddress = require('../utils/addressing');
+const { decode, encode, reject } = require('../utils/helpers');
+
+
+const addResponse = (context, publicKey, { moji, offer }) => {
+  if (!moji || moji.length === 0) {
+    return reject('No moji specified');
+  }
+
+  if (!offer) {
+    return reject('No offer specified');
+  }
+
+  const signer = getAddress.collection(publicKey);
+
+  return context.getState(moji.concat(signer, offer))
+    .then(state => {
+      if (state[signer].length === 0) {
+        return reject('Signer does not have a collection:', publicKey);
+      }
+
+      if (state[offer].length === 0) {
+        return reject('Specified offer does not exist:', offer);
+      }
+
+      for (let mojiAddress of moji) {
+        if (state[mojiAddress].length === 0) {
+          return reject('Specified moji does not exist:', mojiAddress);
+        }
+      }
+
+      moji = moji.sort();
+      const decodedOffer = decode(state[offer]);
+
+      for (let response of decodedOffer.responses) {
+        const responseExists = response.moji.length === moji.length
+          && response.moji.every((m, i) => m === moji[i]);
+
+        if (responseExists) {
+          return reject('A response already exists for moji:', moji.join(', '));
+        }
+      }
+
+      const signerIsOwner = publicKey === decodedOffer.owner;
+      const decodedMoji = moji.map(address => {
+        return Object.assign({ address }, decode(state[address]));
+      });
+
+      if (decodedOffer.owner === decodedMoji[0].owner) {
+        const message = 'Response moji and offer have same owner:';
+        return reject(message, decodedOffer.owner);
+      }
+
+      const approver = signerIsOwner
+        ? decodedMoji[0].owner
+        : decodedOffer.owner;
+
+      for (let moji of decodedMoji) {
+        if (signerIsOwner && moji.owner !== approver) {
+          return reject('Moji must share owner with others:', moji.address);
+        }
+
+        if (!signerIsOwner && moji.owner !== publicKey) {
+          return reject('Signer must own specified moji:', moji.address);
+        }
+      }
+
+      const listing = getAddress.sireListing(decodedMoji[0].owner);
+
+      return context.getState([ listing ])
+        .then(state => {
+
+          if (state[listing].length !== 0) {
+            const sire = decode(state[listing]).sire;
+
+            for (let offered of moji) {
+              if (offered === sire) {
+                return reject('Specified moji listed as a sire:', offered);
+              }
+            }
+          }
+
+          const update = {};
+          decodedOffer.responses.push({ approver, moji });
+          update[offer] = encode(decodedOffer);
+
+          return context.setState(update);
+        });
+    });
+};
+
+module.exports = addResponse;

--- a/code/part-two/processor/handler.js
+++ b/code/part-two/processor/handler.js
@@ -10,6 +10,7 @@ const selectSire = require('./actions/select_sire');
 const breedMoji = require('./actions/breed_moji');
 const createOffer = require('./actions/create_offer');
 const cancelOffer = require('./actions/cancel_offer');
+const addResponse = require('./actions/add_response');
 
 
 class MojiHandler extends TransactionHandler {
@@ -39,6 +40,8 @@ class MojiHandler extends TransactionHandler {
       return createOffer(context, publicKey, payload);
     } else if (action === 'CANCEL_OFFER') {
       return cancelOffer(context, publicKey, payload);
+    } else if (action === 'ADD_RESPONSE') {
+      return addResponse(context, publicKey, payload);
     } else {
       return reject('Unknown action:', action);
     }

--- a/code/part-two/processor/test/06-AddResponse.js
+++ b/code/part-two/processor/test/06-AddResponse.js
@@ -1,0 +1,283 @@
+'use strict';
+
+const { expect } = require('chai');
+const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');
+
+const MojiHandler = require('../handler');
+const getAddress = require('../utils/addressing');
+const { decode } = require('../utils/helpers');
+const Txn = require('./mocks/txn');
+const Context = require('./mocks/context');
+
+describe('Add Response', function() {
+  let handler = null;
+  let context = null;
+  let offer = null;
+  let ownerPub = null;
+  let ownerPriv = null;
+  let responderPub = null;
+  let responderPriv = null;
+  let moji = null;
+
+  before(function() {
+    handler = new MojiHandler();
+  });
+
+  beforeEach(function() {
+    context = new Context();
+    const ownerTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const responderTxn = new Txn({ action: 'CREATE_COLLECTION' });
+
+    ownerPub = ownerTxn._publicKey;
+    ownerPriv = ownerTxn._privateKey;
+    responderPub = responderTxn._publicKey;
+    responderPriv = responderTxn._privateKey;
+
+    return handler.apply(responderTxn, context)
+      .then(() => {
+        const address = getAddress.collection(responderPub);
+        moji = decode(context._state[address]).moji.sort();
+        return handler.apply(ownerTxn, context);
+      })
+      .then(() => {
+        const ownerAddress = getAddress.collection(ownerPub);
+        const { moji } = decode(context._state[ownerAddress]);
+        offer = getAddress.offer(ownerTxn._publicKey)(moji);
+
+        const offerTxn = new Txn({ action: 'CREATE_OFFER', moji }, ownerPriv);
+        return handler.apply(offerTxn, context);
+      });
+  });
+
+  it('should add a response with multiple moji', function() {
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have one response').to.have.lengthOf(1);
+
+        expect(responses[0].approver, 'Response should need owner approval')
+          .to.equal(ownerPub);
+        expect(responses[0].moji, 'Response should include the moji offered')
+          .to.deep.equal(moji);
+      });
+  });
+
+  it('should add a response with a single moji', function() {
+    moji = moji.slice(0, 1);
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const responses = decode(context._state[offer]).responses;
+        expect(responses, 'Offer should have one response').to.have.lengthOf(1);
+
+        expect(responses[0].approver, 'Response should need owner approval')
+          .to.equal(ownerPub);
+        expect(responses[0].moji, 'Response should include the moji offered')
+          .to.deep.equal(moji);
+      });
+  });
+
+  it('should add a response from the offer owner', function() {
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, ownerPriv);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const { responses } = decode(context._state[offer]);
+        expect(responses[0].approver, 'Response should need responder approval')
+          .to.equal(responderPub);
+      });
+  });
+
+  it('should sort the moji in the response', function() {
+    moji = moji.reverse();
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .then(() => {
+        const { responses } = decode(context._state[offer]);
+        expect(responses[0].moji, 'Response should sort the offered moji')
+          .to.have.ordered.members(moji.sort());
+      });
+  });
+
+  it('should reject responses identical to one previously added', function() {
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+    const repeatTxn = new Txn({
+      action: 'ADD_RESPONSE',
+      moji: moji.reverse(),
+      offer
+    }, responderPriv);
+
+    return handler.apply(txn, context)
+      .then(() => handler.apply(repeatTxn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have one response').to.have.lengthOf(1);
+      });
+  });
+
+  it('should not reject responses that are subsets or supersets', function() {
+    const getAddTxn = l => {
+      const payload = { action: 'ADD_RESPONSE', moji: moji.slice(0, l), offer };
+      return new Txn(payload, responderPriv);
+    };
+
+    return handler.apply(getAddTxn(2), context)
+      .then(() => handler.apply(getAddTxn(1), context))
+      .then(() => handler.apply(getAddTxn(3), context))
+      .then(() => {
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'There should be three responses')
+          .to.have.lengthOf(3);
+      });
+  });
+
+  it('should reject public keys with no Collection', function() {
+    delete context._state[getAddress.collection(responderPub)];
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+
+  it('should reject a response when moji is not set', function() {
+    const moji = [];
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+
+  it('should reject a response when offer is not set', function() {
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji }, responderPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it('should reject a response with a moji that does not exist', function() {
+    delete context._state[moji[1]];
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+
+  it('should reject a response that includes a Sire', function() {
+    const sire = moji[1];
+    const sireTxn = new Txn({ action: 'SELECT_SIRE', sire }, responderPriv);
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(sireTxn, context)
+      .then(() => handler.apply(txn, context))
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+
+  it('should reject a response with an offer that does not exist', function() {
+    delete context._state[offer];
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, responderPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+      });
+  });
+
+  it("should reject a response with offer owner's moji", function() {
+    const { moji } = decode(context._state[getAddress.collection(ownerPub)]);
+    const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, ownerPriv);
+
+    return handler.apply(txn, context)
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+
+  it('should reject public keys that do not own offer or all moji', function() {
+    const fraudTxn = new Txn({ action: 'CREATE_COLLECTION' });
+    const fraudPriv = fraudTxn._privateKey;
+    const fraudPub = fraudTxn._publicKey;
+
+    return handler.apply(fraudTxn, context)
+      .then(() => {
+        const fraud = decode(context._state[getAddress.collection(fraudPub)]);
+        moji = fraud.moji.slice(0, 2).concat(moji.slice(0, 1));
+        const txn = new Txn({ action: 'ADD_RESPONSE', moji, offer }, fraudPriv);
+        return handler.apply(txn, context);
+      })
+      .catch(err => {
+        expect(err, 'Error should be an InvalidTransaction')
+          .to.be.instanceOf(InvalidTransaction);
+        return true;
+      })
+      .then(wasRejected => {
+        expect(wasRejected, 'Transaction should be rejected').to.be.true;
+        const { responses } = decode(context._state[offer]);
+        expect(responses, 'Offer should have no responses').to.be.empty;
+      });
+  });
+});

--- a/code/part-two/processor/utils/helpers.js
+++ b/code/part-two/processor/utils/helpers.js
@@ -9,10 +9,21 @@ const hash = (str, length = 128) => {
   return createHash('sha512').update(str).digest('hex').slice(0, length);
 };
 
+// Recursively returns all the keys of an object and nested objects;
+const deepKeys = obj => {
+  if (!obj || typeof obj !== 'object') {
+    return [];
+  }
+
+  const keys = Array.isArray(obj) ? [] : Object.keys(obj);
+  const values = Array.isArray(obj) ? obj : Object.values(obj);
+
+  return values.reduce((keys, value) => keys.concat(deepKeys(value)), keys);
+};
+
 // Encodes an object as a Buffer of sorted JSON string
-// Only works with objects with a depth of 1
 const encode = obj => {
-  const jsonString = JSON.stringify(obj, Object.keys(obj).sort());
+  const jsonString = JSON.stringify(obj, deepKeys(obj).sort());
   return Buffer.from(jsonString);
 };
 


### PR DESCRIPTION
Based on #50 and #53, only the last three commits are a part of this PR.

Adds tests for and implements the ADD_RESPONSE action. Tests can be be run with `npm test` from the processor directory.

Closes #19 