### PR TITLE
Fix Apache redirecting away from bundle.js

### DIFF
--- a/code/part-two/client/Dockerfile
+++ b/code/part-two/client/Dockerfile
@@ -16,8 +16,9 @@ RequestHeader set X-Forwarded-Path \"/api\"\n\
 \n\
 LoadModule rewrite_module modules/mod_rewrite.so\n\
 RewriteEngine On\n\
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-f [OR]\n\
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} !-d\n\
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]\n\
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d\n\
+RewriteRule ^ - [L]\n\
 RewriteCond %{REQUEST_FILENAME} !^/api\n\
 RewriteRule ^ /index.html\n\
 \n\


### PR DESCRIPTION
Apache is erroneously redirecting bundle.js to index.html, making it impossible to load the web app. This fixes that problem.

Test by running `docker-compose up --build`, and then attempting the following:

_Curl commands_
- `curl localhost:8000`
- `curl localhost:8000/bundle.js`
- `curl localhost:8000/api/blocks`

_URLs in browser_
- `http://localhost:8000`
- `http://localhost:8000/api/blocks`