### PR TITLE
Add scripts for publishing a problemified repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,11 @@
 # Contributing
 
-In order to unify the internal development of this curriculum, as well as guide
-any external contributions, here are a few guidelines for contributing to this
-repo.
+Thanks for considering contributing to this project! Here are a few guidelines
+to help speed things up and unify development.
 
 ## Reporting Bugs or Issues
 
-This project uses GitHub issues to track bugs, enhancements, or other tasks.
+This project uses GitHub issues to track bugs, enhancements, and other tasks.
 
 To create a new Issue:
 
@@ -17,53 +16,62 @@ underneath the name of this repo above.
 [New Issue button](https://github.com/hyperledger/education-cryptobunnies/issues/new)
 on the right side of the page.
 3. Enter a title and description for the issue.
-4. Select a label on the right side ([see below](#labels)).
+4. If applicable, select a label on the right side (such as "bug").
 5. Click _"Submit new issue"_.
 
 The title should be a concise label identifying the bug or feature, while the
-_"Leave a comment"_ section below the title should contain a description with
-as much detail as possible. For bugs or typos be sure to include:
+_"Leave a comment"_ section below should contain a description with as much
+detail as possible. For bugs or typos this might include:
 
-- The specific behavior, and what caused that behavior
+- The specific behavior, and what behavior you expected
+- What steps someone else could take to reproduce the bug
 - Any console logs or other diagnostic information
 - Filenames and line numbers if possible (especially for typos)
 
-### Labels
+## Making Code Contributions
 
-There are a few common labels we may use, and encourage any contributors to use
-when opening an issue:
+Like many projects on GitHub, contributions are submitted by creating a fork of
+the repo, making some changes there, and then submitting them back as a Pull
+Request for review. A detailed explanation of the workflow is provided below.
+While we are open to any help you'd like to give, if you are looking for a good
+place to start, you might checkout the _Issues_ page and see if there is
+anything labeled "help wanted" that you could tackle.
 
-- **bug** - any bug, typo, or other misbehavior that needs to be fixed
-- **enhancement** - the implementation of any new features
-- **design** - blueprint for new features, this work may happen outside of this
-repo but progress will still be tracked here
-- **help wanted** - issues which we would specifically like external help for
+### Submitting Pull Requests
 
-## Submitting Pull Requests
+While the fork to PR process is fairly standard, somewhat more unusual is that
+`master` is _not_ the branch to make a PR against. Here master is not the
+source of truth, but a collection of generated stub functions for students to
+fill out. The original source of this code is actually in the `staging` branch,
+and _all_ PRs should be made against staging.
+
+The detailed process is as follows:
 
 1. Create a personal fork of this repository.
-2. Create a topic branch specific to the bug/enhancement you are addressing.
-3. Submit a pull request.
+2. Starting from `staging`, create a topic branch specific to your changes.
+3. Submit a pull request from the topic branch on your fork to `staging` on
+   this repo.
 4. Add other developers as reviewers.
 5. Make changes as requested by rebasing the appropriate commits, and then
-force-pushing to your branch.
+   force-pushing to your branch.
 
 Pull requests can be merged once all requests for change have been addressed,
-and when approved by at least one other developer. Project maintainers will
-personally merge their own PRs, as well as those of external contributors which
-have received the necessary approvals. When merging someone else's PR,
-maintainers should use the _"Create a merge commit"_ option, but when merging
-their own work it is preferable to use the _"Rebase and merge"_ option.
+and when approved by at least one project maintainer. The actual merge will be
+done by a maintainer as well.
 
-## Commit Style
+Note, maintainers should take care when merging to always use the
+_"Create a merge commit"_ option, as rebasing will result in important
+information about the commit history being lost later when the prompt and
+solution files are generated.
 
-Commits should be as small as possible, but no smaller. Ideally, they
-should be an "atomic" change to the repo, which adds a single new piece of
-functionality or fixes a single bug, but if broken down any smaller would not
-provide anything of value. Great commits can be cherry-picked out of their PRs
-and still function properly.
+### Commit Style
 
-For commit message style, follow
+Commits should be as small as possible, but no smaller. Ideally, they should be
+an "atomic" change to the repo, which add a single new piece of functionality
+or fix a single bug, but if broken down any smaller would not provide anything
+of value. This is a subjective measure, but use your best judgment.
+
+For the commit message, follow
 [Chris Beams's Seven Rules](https://chris.beams.io/posts/git-commit/#seven-rules):
 
 - Separate subject from body with a blank line
@@ -75,8 +83,9 @@ For commit message style, follow
 - Use the body to explain what and why vs. how
 
 In addition to these rules, the commit body should reference the number for the
-issue they address. For bug fixes use the syntax: `Fixes #XX`, and for
-enhancements use the syntax: `Closes #XX`.
+issue they address. For bug fixes use the syntax: `Fixes #XXX`, and for
+enhancements use the syntax: `Closes #XXX`. This information can also go into
+the PR message later.
 
 Finally, each commit message must include a _"Signed-off-by"_ line, including
 the developer's name and email. This sign-off indicates that you agree the
@@ -88,16 +97,15 @@ Git can automatically add this signature by using the `-s` flag:
 git commit -s
 ```
 
-## JavaScript Style
+### JavaScript Style
 
-This project follows the basic
-[Hack Reactor Style Guide](https://github.com/hackreactor-labs/eslint-config-hackreactor),
-with the addition that lines should be limited to 80 characters in length. An
-`.eslintrc.json` file with these rules is included in the root project
+This project follows a slightly modified version of the
+[Hack Reactor Style Guide](https://github.com/hackreactor-labs/eslint-config-hackreactor).
+An `.eslintrc.json` file with these rules is included in the root project
 directory. Any contributor writing JavaScript code should
-[install ESLint](https://eslint.org/docs/user-guide/getting-started)
-and run it on their code before submitting a PR. The easiest way to do this is
-simply to run:
+[install ESLint](https://eslint.org/docs/user-guide/getting-started) and run it
+on their code before submitting a PR. The easiest way to do this is simply to
+run:
 
 ```bash
 npm install -g eslint
@@ -106,3 +114,75 @@ npm install -g eslint
 ```bash
 eslint ./
 ```
+
+## Prompt Generation Syntax
+
+This repo uses special comment-based tags to differentiate between solution code and prompts. Later, these tags are used to separate the prompts into the `master` branch, and the solution code into the `solution` branch. The syntax is a slightly more opinionated version of [this problemify repo](LINK CAN GO HEAR PLS). A typical example might look this:
+
+```javascript
+const hello = name => {
+  /* START PROBLEM
+  // Your code here
+
+  END PROBLEM */
+  // START SOLUTION
+  console.log(`Hello, ${name}`);
+  // END SOLUTION
+};
+```
+
+In the above code, the function signature will appear in both the prompts and
+the solution code, but the contents of the function will be very different:
+
+`master`
+```javascript
+const hello = name => {
+  // Your code here
+
+};
+```
+
+`solution`
+```javascript
+const hello = name => {
+  console.log(`Hello, ${name}`);
+};
+```
+
+Note that all of the comment-tags were removed from _both_ versions. Also note
+that the publishing script errs on the side of caution. You must write each tag
+_exactly_, on its own line, with the correct style of comment, and in all caps,
+or it will be ignored. Different indentation is the only variation that is
+supported.
+
+There is also a syntax to designate an entire file as solution code:
+```javascript
+/* SOLUTION FILE */
+'use strict';
+
+const bar = require('./foo');
+
+// Do some stuff...
+```
+
+This entire file would be removed from the `master` branch and only be
+published to `solution`. You can also use `/* PROBLEM FILE */` to get the
+opposite effect. As with the other tags, make sure it is entered exactly, same
+comment syntax, capitalization, on its own line. Unlike the other tags, you may
+_not_ indent the file tags, and they _must_ appear on the first line of the
+file.
+
+**Examples:**
+- [Creating a stub function](https://github.com/hyperledger/education-cryptomoji/blob/master/code/part-two/processor/services/encoding.js#L43)
+- [Marking a solution-only file](https://github.com/hyperledger/education-cryptomoji/blob/master/code/part-two/processor/actions/create_collection.js#L1)
+
+### Publishing Updates to `master` and `solution`
+
+Regular contributors need not worry about this, but for maintainers there is a
+`bin/publish` script which does the work of parsing all the tags and pushing
+the generated code to the appropriate branch. It should be run periodically, if
+possible after every PR is merged. Make sure your working directory is clean
+when you run it, and _never_ do any rebasing or force pushing to the upstream
+`master` or `solution` branches. This script pushes to them directly, and only
+ever makes additions. If there is a conflict, then something has gone wrong,
+and needs to be investigated.

--- a/bin/problemify
+++ b/bin/problemify
@@ -1,0 +1,128 @@
+#! /usr/bin/env node
+
+// Modifies a directory to contain only problem code or solution code.
+//
+// Run in one of two modes, specifying a path:
+//   - `problemify --problem ./`
+//   - `problemify --solution ./`
+//
+// Based on the problemify concept by @bcmarinacci
+// https://github.com/bcmarinacci/problemify
+//
+// More strict than that CLI, only matching comments in ALL CAPS. Also modifies
+// the files in place rather than creating new directories (for use with git).
+// Finally, it adds functionality for `/* PROBLEM FILE */` and
+// `/* SOLUTION FILE */` comments on the first line of a file. These will
+// delete the file if in solution mode or problem mode respectfully.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+
+const IGNORED = ['node_modules', 'bundle.js'];
+const EXTENSIONS = ['.js', '.jsx'];
+const PROBLEM_RE = new RegExp([
+  '.*\\/\\/.*START SOLUTION.*\\n[\\s\\S]*?.*\\/\\/.*END SOLUTION.*\\n',
+  '.*\\/\\*.*START PROBLEM.*\\n',
+  '.*END PROBLEM.*\\*\\/.*\\n',
+  '\\/\\* PROBLEM FILE \\*\\/\\n'
+].join('|'), 'gm');
+const SOLUTION_RE = new RegExp([
+  '.*\\/\\*.*START PROBLEM.*\\n[\\s\\S]*?.*END PROBLEM.*\\*\\/.*\\n',
+  '.*\\/\\/.*START SOLUTION.*\\n',
+  '.*\\/\\/.*END SOLUTION.*\\n',
+  '\\/\\* SOLUTION FILE \\*\\/\\n'
+].join('|'), 'gm');
+
+const printUsage = () => {
+  console.log(
+`
+usage: problemify mode path
+
+Modifies JS source code in directory to be either a problem or a solution.
+
+positional arguments:
+  mode                  One of: -p, -s, --problem, or --solution
+  path                  Path to source code
+
+optional arguments
+  -h, --help            Print this help text
+`
+  );
+}
+
+const parseArgs = ([ _, __, modeFlag, pathName ]) => {
+  if (['-h', '--help'].includes(modeFlag)) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (!['-p', '-s','--problem', '--solution'].includes(modeFlag)) {
+    console.error('Error: Must specify a mode!');
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!pathName) {
+    console.error('Error: Must specify a path!');
+    printUsage();
+    process.exit(1);
+  }
+
+  const mode = ['-p', '--problem'].includes(modeFlag) ? 'P' : 'S';
+  const fullPath = path.resolve(process.cwd(), pathName);
+
+  return [ mode, fullPath ];
+}
+
+const concatMap = (array, iterator) => {
+  return array.reduce((mapped, item) => {
+    return mapped.concat(iterator(item));
+  }, [])
+};
+
+const listFiles = dir => {
+  return concatMap(fs.readdirSync(dir), file => {
+    if (IGNORED.includes(file)) {
+      return [];
+    }
+
+    if (fs.statSync(path.join(dir, file)).isDirectory()) {
+      return listFiles(path.join(dir, file))
+    }
+
+    if (EXTENSIONS.includes(path.extname(file))) {
+      return path.join(dir, file);
+    }
+
+    return [];
+  })
+};
+
+const xformFile = mode => path => {
+  fs.readFile(path, 'utf8', (err, code) => {
+    if (err) throw err;
+
+    if (mode === 'P' && code.slice(0, 19) === '/* SOLUTION FILE */') {
+      return fs.unlink(path, err => { if (err) throw err; });
+    }
+
+    if (mode === 'S' && code.slice(0, 18) === '/* PROBLEM FILE */') {
+      return fs.unlink(path, err => { if (err) throw err; });
+    }
+
+    const xformed = mode === 'P'
+      ? code.replace(PROBLEM_RE, '')
+      : code.replace(SOLUTION_RE, '');
+
+    fs.writeFile(path, xformed, 'utf8', err => { if (err) throw err; });
+  });
+};
+
+// Modify files
+const [ MODE, PATH ] = parseArgs(process.argv);
+console.log(`${MODE === 'P' ? 'Problemifying' : 'Solutionifying'}: ${PATH}`);
+
+listFiles(PATH).forEach(xformFile(MODE));

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+# Problemifies the code, then creates new commits and pushes them to the
+# `master` and `solution` branches.
+#
+# Requires `git` and `node`
+
+# Check for uncommitted changes
+if [ -n "$( git diff-index --name-only HEAD -- )" ]
+    then
+        echo "The working directory must be clean to publish"
+        echo "Stash or commit your changes"
+        exit 1
+fi
+
+# Save current environment
+CURR_DIR="$( pwd )"
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"
+CURR_BRANCH="$( git rev-parse --abbrev-ref HEAD )"
+
+# Pull new staging code
+git checkout staging
+git pull upstream staging
+HEAD="$( git rev-parse HEAD )"
+
+# Problemify code
+cd $ROOT_DIR
+bin/problemify -p code/
+git checkout master
+
+# Push to master
+git add .
+git commit -s -m "Problemified code generated from: $HEAD"
+git push upstream master
+
+# Solutionify code
+git checkout staging
+bin/problemify -s code/
+git checkout solution
+
+# Push to solution
+git add .
+git commit -s -m "Solutionified code generated from: $HEAD"
+git push upstream solution
+
+# Reset environment
+cd $CURR_DIR
+git checkout $CURR_BRANCH

--- a/code/part-two/client/source/App.jsx
+++ b/code/part-two/client/source/App.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 

--- a/code/part-two/client/source/Collection.jsx
+++ b/code/part-two/client/source/Collection.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 
 import { MojiItem } from './MojiItem';

--- a/code/part-two/client/source/CollectionList.jsx
+++ b/code/part-two/client/source/CollectionList.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/Moji.jsx
+++ b/code/part-two/client/source/Moji.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/MojiItem.jsx
+++ b/code/part-two/client/source/MojiItem.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/Offer.jsx
+++ b/code/part-two/client/source/Offer.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/OfferList.jsx
+++ b/code/part-two/client/source/OfferList.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/ResponseList.jsx
+++ b/code/part-two/client/source/ResponseList.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/code/part-two/client/source/SignupLogin.jsx
+++ b/code/part-two/client/source/SignupLogin.jsx
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import React from 'react';
 
 import { createKeys, getPublicKey } from './services/signing';

--- a/code/part-two/client/source/index.jsx
+++ b/code/part-two/client/source/index.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 
+// START SOLUTION
 import { App } from './App';
+// END SOLUTION
 
 ReactDOM.render((
   <BrowserRouter>
+    /* START PROBLEM
+    <h1>Hello, Cryptomoji!</h1>
+    END PROBLEM */
+    // START SOLUTION
     <App />
+    // END SOLUTION
   </BrowserRouter>
 ), document.getElementById('app'));

--- a/code/part-two/client/source/services/requests.js
+++ b/code/part-two/client/source/services/requests.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 import axios from 'axios';
 
 import { decode } from './encoding.js';

--- a/code/part-two/processor/actions/accept_response.js
+++ b/code/part-two/processor/actions/accept_response.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/add_response.js
+++ b/code/part-two/processor/actions/add_response.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/breed_moji.js
+++ b/code/part-two/processor/actions/breed_moji.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/cancel_offer.js
+++ b/code/part-two/processor/actions/cancel_offer.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/create_collection.js
+++ b/code/part-two/processor/actions/create_collection.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/create_offer.js
+++ b/code/part-two/processor/actions/create_offer.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');

--- a/code/part-two/processor/actions/select_sire.js
+++ b/code/part-two/processor/actions/select_sire.js
@@ -1,3 +1,4 @@
+/* SOLUTION FILE */
 'use strict';
 
 const { InvalidTransaction } = require('sawtooth-sdk/processor/exceptions');


### PR DESCRIPTION
~Built on top of #79, only the last three commits are new to this PR~

This PR includes two scripts.

- _bin/problemify_: modifies the code in place, turning it either into solution code or problem code
- _bin/publish_: pulls the latest commits from `upstream staging`, and pushes problemified versions to `upstream master` and `upstream solution`

The basic workflow is this:
- Once This PR is merged, I will create solution and staging branches upstream
- All future PRs will be made against staging, not master
- Include problemify-style comments in your code to designate solution vs problem sections
- Periodically (such as after merging new PRs into staging) run `bin/publish`

Problemify syntax:
```javascript
/* SOLUTION FILE */
const fs = require('fs');
...
```
^ This entire file should _only_ be included in the solution branch. It will be deleted from master. The opposite (though probably not useful) is `/* PROBLEM FILE */`.

```javascript
const hello = name => {
  /* START PROBLEM
  // Your code here

  END PROBLEM */
  // START SOLUTION
  console.log(`Hello, ${name}`);
  // END SOLUTION
};
```

^ This function will be empty save a comment ("Your code here") on master, and completed on solution. Note that _all_ of the problemify syntax comments will be deleted from both branches.

Also note that this script errs on the side of caution. You most enter these comments exactly as written above (all caps) or they will be missed.

Examples:
- https://github.com/delventhalz/education-cryptomoji/blob/problemify-repo/code/part-two/processor/actions/create_collection.js#L1
- https://github.com/delventhalz/education-cryptomoji/blob/problemify-repo/code/part-two/processor/services/encoding.js#L43