### PR TITLE
Fix publish script

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -19,28 +19,42 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"
 CURR_BRANCH="$( git rev-parse --abbrev-ref HEAD )"
 
 # Pull new staging code
+# when testing, use `git checkout origin/staging`
+git checkout upstream/staging
+git branch -f staging
 git checkout staging
-git pull upstream staging
 HEAD="$( git rev-parse HEAD )"
 
 # Problemify code
 cd $ROOT_DIR
 bin/problemify -p code/
+rsync -rv --exclude=.git/ --exclude=node_modules/ ./ tmp/
+git checkout -f upstream/master
+git branch -f master
 git checkout master
+rsync -rv --exclude=.git/ --exclude=node_modules/ tmp/ ./
+rm -rf tmp/
 
 # Push to master
 git add .
 git commit -s -m "Problemified code generated from: $HEAD"
+# when testing, use `git push -f origin master`
 git push upstream master
 
 # Solutionify code
 git checkout staging
 bin/problemify -s code/
+rsync -rv --exclude=.git/ --exclude=node_modules/ ./ tmp/
+git checkout -f upstream/solution
+git branch -f solution
 git checkout solution
+rsync -rv --exclude=.git/ --exclude=node_modules/ tmp/ ./
+rm -rf tmp/
 
 # Push to solution
 git add .
 git commit -s -m "Solutionified code generated from: $HEAD"
+# when testing, use `git push -f origin solution`
 git push upstream solution
 
 # Reset environment


### PR DESCRIPTION
Fixes #102.

This PR requires a little work to test as the changes in the PR actually rely on the current status of `hyperledger:staging` (and until this PR is merged... the changes won't be on `hyperledger:staging`).

So, I've tested it out on my own fork! Here are the commits that the script produced:
* problemified: https://github.com/therobinkim/education-cryptomoji/commit/4a83e2eb8a391160760276372ee040fb179f1516
* solutionified: https://github.com/therobinkim/education-cryptomoji/commit/146103524c3065f10dbba0efb336e71f2d3cbdb7

We will be able to more accurately test this PR once it's been merged (which is a bit unfortunate).