### PR TITLE
Fix links to lecture videos in READMEs

### DIFF
--- a/code/part-one/README.md
+++ b/code/part-one/README.md
@@ -51,8 +51,8 @@ data structure and the technologies that power it: hashing, signatures, and
 consensus. The lecture itself is 15 minutes long with an additional 10 minutes
 of Q&A. They are included in this repo as two MP4 files:
 
-- [Blockchain Overview Lecture (MP4)](../../teaching/videos/01a_blockchain_lecture.m4v)
-- [Blockchain Overview Questions (MP4)](../../teaching/videos/01b_blockchain_qa.m4v)
+- [Blockchain Overview Lecture (MP4)](../../teaching/videos/01a_blockchain_lecture.mp4)
+- [Blockchain Overview Questions (MP4)](../../teaching/videos/01b_blockchain_qa.mp4)
 
 In addition to the video, the slides are available in a variety of formats. The
 general blockchain section is the first 8 slides:

--- a/code/part-two/README.md
+++ b/code/part-two/README.md
@@ -174,12 +174,12 @@ development in detail. It is broken into five parts, the first of which is a
 overview of blockchains generally, which you may have already watched in part
 one. Each part is available as an MP4 file:
 
-- [01a Blockchain Overview Lecture (MP4)](../../teaching/videos/01a_blockchain_lecture.m4v)
-- [01b Blockchain Overview Questions (MP4)](../../teaching/videos/01b_blockchain_qa.m4v)
-- [02 Sawtooth Overview (MP4)](../../teaching/videos/02_sawtooth_overview.m4v)
-- [03 Writing Transaction Processors (MP4)](../../teaching/videos/03_transaction_processors.m4v)
-- [04 Writing Clients (MP4)](../../teaching/videos/04_writing_clients.m4v)
-- [05 Sprint Design (MP4)](../../teaching/videos/05_sprint_design.m4v)
+- [01a Blockchain Overview Lecture (MP4)](../../teaching/videos/01a_blockchain_lecture.mp4)
+- [01b Blockchain Overview Questions (MP4)](../../teaching/videos/01b_blockchain_qa.mp4)
+- [02 Sawtooth Overview (MP4)](../../teaching/videos/02_sawtooth_overview.mp4)
+- [03 Writing Transaction Processors (MP4)](../../teaching/videos/03_transaction_processors.mp4)
+- [04 Writing Clients (MP4)](../../teaching/videos/04_writing_clients.mp4)
+- [05 Sprint Design (MP4)](../../teaching/videos/05_sprint_design.mp4)
 
 The slides are also available in a variety of formats:
 


### PR DESCRIPTION
The lectures use a `.mp4` extension, not the `.m4v` extension.

Thanks to @schaeferCode for finding this one.