### PR TITLE
Add expect for previousHash to addBlock test

### DIFF
--- a/code/part-one/tests/02-Blockchain.js
+++ b/code/part-one/tests/02-Blockchain.js
@@ -135,8 +135,11 @@ describe('Blockchain module', function() {
       blockchain.addBlock([transaction]);
 
       expect(blockchain.blocks).to.have.lengthOf(2);
-      expect(blockchain.getHeadBlock().transactions)
-        .to.deep.equal([transaction]);
+
+      const head = blockchain.getHeadBlock();
+      const genesis = blockchain.blocks[0];
+      expect(head.transactions).to.deep.equal([transaction]);
+      expect(head.previousHash).to.equal(genesis.hash);
     });
 
     it('should be able to get balance for an address', function() {


### PR DESCRIPTION
Fixes #96

Ensures that students set the previousHash properly when adding blocks to the blockchain. Previously this was not checked.

_To test:_

```bash
cd code/part-one/
npm install
npm test
```

These tests should all pass. Then if you modify line 140 of `code/part-one/blockchain.js` so it reads:

```javascript
    const block = new Block(transactions, this.getHeadBlock().previousHash);
```

This is an error, and if you run `npm test` again, it should be caught by the tests. Previously it would have been missed.