### PR TITLE
Fix namespace typo in isValidAddress test

### DIFF
--- a/code/part-two/processor/tests/01-Services.js
+++ b/code/part-two/processor/tests/01-Services.js
@@ -251,7 +251,7 @@ describe('Processor Services', function() {
       });
 
       it('should reject an address that is not hex', function() {
-        const address = '5f4d7702' + 'za' + randomBytes(30).toString('hex');
+        const address = '5f4d7602' + 'za' + randomBytes(30).toString('hex');
 
         expect(addressing.isValidAddress(address)).to.be.false;
       });


### PR DESCRIPTION
Fixes #110

The test that ensured isValidAddress rejected non-hex input used the wrong namespace, which meant it would reject the test address based on namespace before even looking at whether or not it was hex.

_To test:_

```bash
cd code/part-two/processor/
npm install
npm test
```

All of the tests should pass. Then, if you modify line 121 of `code/part-two/processor/services/addressing.js` so it reads:

```javascript
  const pattern = `^${NAMESPACE}[0-9a-z]{64}$`;
```

The tests should fail correctly. Previously this error would have snuck past the tests.