### PR TITLE
Fix <MojiListItem/> and <BreedDropdownMenu/> not rendering when no sire selected

### DIFF
--- a/code/part-two/client/.babelrc
+++ b/code/part-two/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "react"]
+}

--- a/code/part-two/client/.babelrc
+++ b/code/part-two/client/.babelrc
@@ -1,3 +1,17 @@
 {
-  "presets": ["env", "react"]
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "> 5%",
+            "not ie 11",
+            "not op_mini all"
+          ]
+        }
+      }
+    ],
+    "react"
+  ]
 }

--- a/code/part-two/client/source/BreedDropdownMenu.jsx
+++ b/code/part-two/client/source/BreedDropdownMenu.jsx
@@ -36,10 +36,10 @@ export class BreedDropdownMenu extends React.Component {
       .then(userCollection => {
         this.setState({ userCollection });
         return Promise.all([
-          getSires(this.props.publicKey),
+          getSires(this.props.publicKey).catch(() => {}),
           ...userCollection.moji.map(getMoji)
         ]);
-      }).then(([sire, ...mojiList]) => {
+      }).then(([sire = {}, ...mojiList]) => {
         this.setState({
           userCollection: {
             moji: mojiList.map(moji => {

--- a/code/part-two/client/source/MojiListItem.jsx
+++ b/code/part-two/client/source/MojiListItem.jsx
@@ -9,47 +9,18 @@ export class MojiListItem extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isLoaded: false,
       isSire: false,
       mojiView: null
     };
   }
 
-  componentDidMount() {
-    Promise.resolve(this.props.address)
-      .then(address => {
-        // if it's an address, then get the details
-        if (!!address) {
-          return getMoji(this.props.address);
-        }
-        // otherwise, the details were already passed in
-        return this.props.moji;
-      })
-      .then(moji => {
-        this.setState({
-          mojiView: parseDna(moji.dna).view
-        });
+  async componentDidMount() {
+    let moji = this.props.moji || await getMoji(this.props.address);
+    this.setState({ mojiView: parseDna(moji.dna).view });
 
-        if (moji.isSire) {
-          this.setState({ isSire: true, isLoaded: true });
-          // if we know moji is a sire, break out of the promise chain
-          return Promise.reject('This moji is a sire');
-        } else {
-          return getSires(moji.owner);
-        }
-      })
-      .then(sire => {
-        const isSire =
-          sire.address === (this.props.address || this.props.moji.address);
-        this.setState({ isSire, isLoaded: true });
-      })
-      .catch(err => {
-        if (err === 'This moji is a sire') {
-          // don't do anything bc it's not an actual error
-        } else {
-          console.error(err);
-        }
-      });
+    let address = moji.address;
+    var isSire = moji.isSire || (await getSires(moji.owner)).address === address;
+    this.setState({ isSire });
   }
 
   render() {
@@ -64,9 +35,7 @@ export class MojiListItem extends React.Component {
             to={'/moji/' + (this.props.address || this.props.moji.address)}
             className="card-title card-link"
           >
-            {this.state.isLoaded
-              && (this.state.mojiView || this.props.address)
-            }
+            {this.state.mojiView}
             {' '}
             {sireIndicator}
           </Link>

--- a/code/part-two/client/webpack.config.js
+++ b/code/part-two/client/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
+            cacheDirectory: true
           }
         }
       }

--- a/code/part-two/client/webpack.config.js
+++ b/code/part-two/client/webpack.config.js
@@ -21,7 +21,6 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['env', 'react']
           }
         }
       }


### PR DESCRIPTION
This PR fixes critical bugs where `<MojiListItem/>` and `<BreedDropdownMenu/>` did not render properly when the logged in user did not have any sires selected.

Once this PR is approved, PR #115 should be approved as well.
PR #99 was previously modified to target the `feat/client-breed` branch instead, so once this PR is approved and merged, PR #115 will handle bringing the changes into the `staging` branch. (Finally!)

`<MojiListItem/>` is working again:
![image](https://user-images.githubusercontent.com/7613067/44194438-a200d880-a0fb-11e8-9db4-02d546061dde.png)

`<BreedDropdownMenu/>` is working again:
![image](https://user-images.githubusercontent.com/7613067/44194448-adec9a80-a0fb-11e8-94ac-83cbd8071441.png)
